### PR TITLE
Moved used strict to be invoked in the context of MiniProfiler

### DIFF
--- a/includes.js
+++ b/includes.js
@@ -1,5 +1,5 @@
-﻿"use strict";
 var MiniProfiler = (function () {
+    "use strict";
     var $,
         _
         ;


### PR DESCRIPTION
By including "use strict" in the top of the file it is causing strict mode to be invoked globally for the file. This isn't a problem if it is just one file, but if it is combined into another file it would invoke strict mode for that.
