### PR TITLE
Added explicit contentType and processData to the $.ajax call

### DIFF
--- a/includes.js
+++ b/includes.js
@@ -131,6 +131,8 @@ var MiniProfiler = (function () {
                     data: { id: id, clientPerformance: clientPerformance, clientProbes: clientProbes, popup: 1 },
                     dataType: 'json',
                     type: 'POST',
+					contentType: "application/x-www-form-urlencoded; charset=UTF-8",
+					processData: true,                    
                     success: function (json) {
                         fetchedIds.push(id);
                         if (json != "hidden") {


### PR DESCRIPTION
Added explicit contentType and processData to the $.ajax call, so it doesn't interfere with $.ajaxSetup

At the moment, having:
contentType: "application/json",
processData: false
in the $.ajaxSetup of your application interferes with the MiniProfiler ajax calls, making the MiniProfiler not show up.

Setting these parameters explicit fixes this problem.
