### PR TITLE
Fixes infinite recursion issue when re-using XmlHttpRequest objects

### DIFF
--- a/includes.js
+++ b/includes.js
@@ -693,19 +693,22 @@ var MiniProfiler = (function () {
 
           XMLHttpRequest.prototype.send = function sendReplacement(data) {
             if (this.onreadystatechange) {
-              this._onreadystatechange = this.onreadystatechange;
+                if (typeof (this.miniprofiler) == 'undefined' || typeof (this.miniprofiler.prev_onreadystatechange) == 'undefined') {
+                    this.miniprofiler = { prev_onreadystatechange: this.onreadystatechange };
 
-              this.onreadystatechange = function onReadyStateChangeReplacement() {
-                if (this.readyState == 4) {
-                  var stringIds = this.getResponseHeader('X-MiniProfiler-Ids');
-                  if (stringIds) {
-                    var ids = typeof JSON != 'undefined' ? JSON.parse(stringIds) : eval(stringIds);
-                    fetchResults(ids);
-                  }
+                    this.onreadystatechange = function onReadyStateChangeReplacement() {
+                        if (this.readyState == 4) {
+                            var stringIds = this.getResponseHeader('X-MiniProfiler-Ids');
+                            if (stringIds) {
+                                var ids = typeof JSON != 'undefined' ? JSON.parse(stringIds) : eval(stringIds);
+                                fetchResults(ids);
+                            }
+                        }
+
+                        if (this.miniprofiler.prev_onreadystatechange != null)
+                            return this.miniprofiler.prev_onreadystatechange.apply(this, arguments);
+                    };
                 }
-
-                return this._onreadystatechange.apply(this, arguments);
-              }
             }
 
             return _send.apply(this, arguments);


### PR DESCRIPTION
Fix for stack overflows and out of memory errors from JS when
miniprofiler is used in conjunction with other 3rd party libraries like
Angular as they re-use the XmlHttpRequest.

Fix was originally made by jcoutch but never made it to the master
branch :

https://github.com/SamSaffron/MiniProfiler/pull/195
