### PR TITLE
Fixes issue with wrong bottom position of popup in case of scrolling.

### DIFF
--- a/includes.js
+++ b/includes.js
@@ -355,7 +355,7 @@ var MiniProfiler = (function () {
             isBottom = options.renderPosition.indexOf("bottom") != -1; // is this rendering on the bottom (if no, then is top by default)
 
         if (isBottom) {
-            var bottom = $(window).height() - button.offset().top - button.outerHeight(), // get bottom of button
+            var bottom = $(window).height() - button.offset().top - button.outerHeight() + $(window).scrollTop(), // get bottom of button
                 isLeft = options.renderPosition.indexOf("left") != -1;
 
             var horizontalPosition = isLeft ? "left" : "right";


### PR DESCRIPTION
Hi there.
We have faced with a problem related to positioning of popup window in case when the window is scrolled and miniprofiler is configured to display itself in the bottom right corner. See the attached screenshots.
In the second case you can see only a part of popup, and it becomes completely invisible if the window is scrolled down even more.
![mp1](https://cloud.githubusercontent.com/assets/3062744/10424169/7acccc14-70d5-11e5-9ac1-2e5310a78986.PNG)
![mp2](https://cloud.githubusercontent.com/assets/3062744/10424170/7b002a5a-70d5-11e5-9693-c05d10dbe3dc.PNG)
