### PR TITLE
Detection of duplicate SQL commands

### DIFF
--- a/includes.js
+++ b/includes.js
@@ -213,17 +213,22 @@ var MiniProfiler = (function () {
                     Count: 0
                 };
                 var duplicates = {};
+                var commandTextSanitizing = /(DECLARE .*\n)/g;
+
                 for (var i = 0; i < customTimings.length; i++) {
                     var customTiming = customTimings[i];
                     customTiming.ParentTimingId = timing.Id;
                     customStat.Duration += customTiming.DurationMilliseconds;
                     customStat.Count++;
-                    if (customTiming.CommandString && duplicates[customTiming.CommandString]) {
-                        customTiming.IsDuplicate = true;
-                        timing.HasDuplicateCustomTimings[customType] = true;
-                        json.HasDuplicateCustomTimings = true;
-                    } else {
-                        duplicates[customTiming.CommandString] = true;
+                    if (customTiming.CommandString) {
+                        var sanitizedCommandString = customTiming.CommandString.replace(commandTextSanitizing, '');
+                        if (duplicates[sanitizedCommandString]) {
+                            customTiming.IsDuplicate = true;
+                            timing.HasDuplicateCustomTimings[customType] = true;
+                            json.HasDuplicateCustomTimings = true;
+                        } else {
+                            duplicates[sanitizedCommandString] = true;
+                        }
                     }
                 }
                 timing.CustomTimingStats[customType] = customStat;


### PR DESCRIPTION
Detection of duplicate SQL commands works by comparing the bare command text to each other and if a match was found, the timing is marked as duplicate.
That works pretty well as long as the command text is neither annotated (transaction information) nor contains the command parameter's value.

I use the .net `VerboseSqlServerFormatter` which breaks the duplicate detection because it adds the parameter information to the command text:

``` sql
-- call 1:
DECLARE @EntityKeyValue1 tinyint = 1;

SELECT 
    [Extent1].[id] AS [id], 
    [Extent1].[text] AS [text]
    FROM [dbo].[users] AS [Extent1]
    WHERE [Extent1].[id] = @EntityKeyValue1;
```

``` sql
-- call 2:
DECLARE @EntityKeyValue1 tinyint = 2;

SELECT 
    [Extent1].[id] AS [id], 
    [Extent1].[text] AS [text]
    FROM [dbo].[users] AS [Extent1]
    WHERE [Extent1].[id] = @EntityKeyValue1;
```

The calls are actually the same, just the parameter has changed.

The problematic section is in the [includes.js#L215-L228](https://github.com/MiniProfiler/ui/blob/master/includes.js#L215-L228) file.
The solution would be to just remove "DECLARE .*" from the command text just before it gets added to the duplicate array, but that would mean that include.js has "knowledge" of the sql technology it is used with (sql, mongodb, etc).

What do you say? Can we add this little fix or would that add to much "knowledge"?
